### PR TITLE
MODCFIELDS-8 - Implement DELETE custom field by id endpoint

### DIFF
--- a/ramls/customField.json
+++ b/ramls/customField.json
@@ -6,13 +6,19 @@
   "properties": {
     "id": {
       "type": "string",
-      "description": "The id of the custom field",
-      "example": "department_1"
+      "description": "Unique generated identifier for the custom field",
+      "example": "62d00c36-a94f-434d-9cd2-c7ea159303da"
     },
     "name": {
       "type": "string",
       "description": "The name of the custom field",
-      "example": "Department"
+      "example": "Department",
+      "maxLength": 65
+    },
+    "refId": {
+      "type": "string",
+      "description": "The reference id of the custom field",
+      "example": "department_1"
     },
     "type": {
       "type": "string",

--- a/src/main/java/org/folio/repository/CustomFieldsConstants.java
+++ b/src/main/java/org/folio/repository/CustomFieldsConstants.java
@@ -6,5 +6,6 @@ public class CustomFieldsConstants {
   public static final String JSONB_COLUMN = "jsonb";
   public static final String ID_COLUMN = "id";
 
-  static final String COUNT_CUSTOM_FIELDS_BY_ID = "SELECT COUNT(*) as count from %s WHERE " + ID_COLUMN + " LIKE ?";
+  public static final String REF_ID_REGEX = "(%s_[1-9]{1,})";
+  static final String SELECT_REF_IDS = "SELECT unnest(regexp_matches(" + JSONB_COLUMN + " ->> 'refId', ?)) as values FROM %s";
 }

--- a/src/main/java/org/folio/repository/CustomFieldsRepository.java
+++ b/src/main/java/org/folio/repository/CustomFieldsRepository.java
@@ -22,13 +22,19 @@ public interface CustomFieldsRepository {
   Future<Optional<CustomField>> findById(String id, String tenantId);
 
   /**
-   * Returns count of custom fields with given customFieldId.
+   * Returns a max count of custom fields by given customFieldName.
    */
-  Future<Integer> countById(String customFieldId, String tenantId);
+  Future<Integer> maxRefId(String customFieldName, String tenantId);
+
   /**
    * Returns custom fields that match specified CQL query
    */
   Future<CustomFieldCollection> findByQuery(String query, int offset, int limit, String tenantId);
 
   Future<Boolean> update(CustomField entity, String tenantId);
+
+  /**
+   * Deletes custom field with given id.
+   */
+  Future<Boolean> delete(String id, String tenantId);
 }

--- a/src/main/java/org/folio/rest/impl/CustomFieldsImpl.java
+++ b/src/main/java/org/folio/rest/impl/CustomFieldsImpl.java
@@ -1,7 +1,5 @@
 package org.folio.rest.impl;
 
-import static io.vertx.core.Future.succeededFuture;
-
 import static org.folio.rest.ResponseHelper.respond;
 import static org.folio.rest.jaxrs.resource.CustomFields.PostCustomFieldsResponse.headersFor201;
 import static org.folio.rest.tools.utils.TenantTool.tenantId;
@@ -9,7 +7,6 @@ import static org.folio.rest.tools.utils.TenantTool.tenantId;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -72,8 +69,8 @@ public class CustomFieldsImpl implements CustomFields {
   public void deleteCustomFieldsById(String id, String lang, Map<String, String> okapiHeaders,
                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    asyncResultHandler.handle(succeededFuture(DeleteCustomFieldsByIdResponse.status(Status.NOT_IMPLEMENTED)
-        .build()));
+    Future<Void> deleted = customFieldsService.delete(id, tenantId(okapiHeaders));
+    respond(deleted, v -> DeleteCustomFieldsByIdResponse.respond204(), asyncResultHandler, excHandler);
   }
 
   @Override

--- a/src/main/java/org/folio/service/CustomFieldsService.java
+++ b/src/main/java/org/folio/service/CustomFieldsService.java
@@ -29,4 +29,9 @@ public interface CustomFieldsService {
   Future<CustomField> findById(String id, String tenantId);
 
   Future<CustomFieldCollection> findByQuery(String query, int offset, int limit, String lang, String tenantId);
+
+  /**
+   * Deletes custom field with given id.
+   */
+  Future<Void> delete(String id, String tenantId);
 }

--- a/src/main/resources/templates/db_scripts/create_custom_fields_table.sql
+++ b/src/main/resources/templates/db_scripts/create_custom_fields_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS custom_fields(id VARCHAR(75) PRIMARY KEY , jsonb JSONB NOT NULL);
+CREATE TABLE IF NOT EXISTS custom_fields(id UUID PRIMARY KEY, jsonb JSONB NOT NULL CHECK ((jsonb ->> 'refId'::text) IS NOT NULL));
 
 DROP TRIGGER IF EXISTS set_id_injson_custom_fields ON custom_fields CASCADE;
 DROP TRIGGER IF EXISTS set_id_in_jsonb ON custom_fields CASCADE;
@@ -40,3 +40,28 @@ language 'plpgsql';
 DROP TRIGGER IF EXISTS set_custom_fields_md_json_trigger ON custom_fields CASCADE;
 
 CREATE TRIGGER set_custom_fields_md_json_trigger BEFORE UPDATE ON custom_fields   FOR EACH ROW EXECUTE PROCEDURE set_custom_fields_md_json();
+
+CREATE OR REPLACE FUNCTION update_ref_id()
+RETURNS TRIGGER AS $$
+DECLARE
+    newRefId text;
+    oldRefId text;
+    newCustomFieldName text;
+    oldCustomFieldName text;
+BEGIN
+  newRefId = NEW.jsonb->'refId';
+  oldRefId = OLD.jsonb->'refId';
+  newCustomFieldName = NEW.jsonb->'name';
+  oldCustomFieldName = OLD.jsonb->'name';
+
+  if newRefId ISNULL                         then     newRefId := oldRefId;   end if;
+  if newCustomFieldName = oldCustomFieldName then     newRefId := oldRefId;   end if;
+
+  NEW.jsonb = jsonb_set(NEW.jsonb, '{refId}' ,  newRefId::jsonb , false);
+
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+DROP TRIGGER IF EXISTS update_ref_id_trigger ON custom_fields;
+CREATE TRIGGER update_ref_id_trigger BEFORE UPDATE ON custom_fields FOR EACH ROW EXECUTE PROCEDURE update_ref_id();
+

--- a/src/main/resources/update_ref_id.sql
+++ b/src/main/resources/update_ref_id.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION update_ref_id()
+RETURNS TRIGGER AS $$
+DECLARE
+    newRefId text;
+    oldRefId text;
+    newCustomFieldName text;
+    oldCustomFieldName text;
+BEGIN
+  newRefId = NEW.jsonb->'refId';
+  oldRefId = OLD.jsonb->'refId';
+  newCustomFieldName = NEW.jsonb->'name';
+  oldCustomFieldName = OLD.jsonb->'name';
+
+  if newRefId ISNULL                         then     newRefId := oldRefId;   end if;
+  if newCustomFieldName = oldCustomFieldName then     newRefId := oldRefId;   end if;
+
+  NEW.jsonb = jsonb_set(NEW.jsonb, '{refId}' ,  newRefId::jsonb , false);
+
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+DROP TRIGGER IF EXISTS update_ref_id_trigger ON custom_fields;
+CREATE TRIGGER update_ref_id_trigger BEFORE UPDATE ON custom_fields FOR EACH ROW EXECUTE PROCEDURE update_ref_id();

--- a/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
@@ -5,7 +5,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
-import static org.apache.http.HttpStatus.SC_NOT_IMPLEMENTED;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,6 +13,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import static org.folio.test.util.TestUtil.STUB_TENANT;
 import static org.folio.test.util.TestUtil.readFile;
@@ -40,14 +40,14 @@ import org.folio.test.util.TestBase;
 @RunWith(VertxUnitRunner.class)
 public class CustomFieldsImplTest extends TestBase {
 
-  private static final String FIELD_ID = "department_1";
-  private static final String FIELD_ID_2 = "expiration-date";
+  private static final String STUB_FIELD_ID = "11111111-1111-1111-a111-111111111111";
+  private static final String STUB_FIELD_ID_2 = "22222222-2222-2222-a222-222222222222";
 
   private static final Header USER8 = new Header(XOkapiHeaders.USER_ID, "88888888-8888-4888-8888-888888888888");
   private static final Header USER9 = new Header(XOkapiHeaders.USER_ID, "99999999-9999-4999-9999-999999999999");
 
   private static final String CUSTOM_FIELDS_PATH = "custom-fields";
-  private static final String CUSTOM_FIELDS_ID_PATH = CUSTOM_FIELDS_PATH + "/" + FIELD_ID;
+  private static final String CUSTOM_FIELDS_ID_PATH = CUSTOM_FIELDS_PATH + "/" + STUB_FIELD_ID;
 
 
   @Before
@@ -88,7 +88,7 @@ public class CustomFieldsImplTest extends TestBase {
     final CustomField customField = postWithStatus(CUSTOM_FIELDS_PATH, cfWithAccentName, SC_CREATED, USER8)
       .as(CustomField.class);
 
-    assertEquals("this-is-a-tricky-string_1", customField.getId());
+    assertEquals("this-is-a-tricky-string_1", customField.getRefId());
 
     final Metadata noteTypeMetadata = customField.getMetadata();
 
@@ -104,8 +104,8 @@ public class CustomFieldsImplTest extends TestBase {
 
     final CustomField customField_two = postWithStatus(CUSTOM_FIELDS_PATH, cfWithAccentName, SC_CREATED, USER8)
       .as(CustomField.class);
-    assertEquals("this-is-a-tricky-string_1", customField_one.getId());
-    assertEquals("this-is-a-tricky-string_2", customField_two.getId());
+    assertEquals("this-is-a-tricky-string_1", customField_one.getRefId());
+    assertEquals("this-is-a-tricky-string_2", customField_two.getRefId());
   }
 
   @Test
@@ -117,14 +117,15 @@ public class CustomFieldsImplTest extends TestBase {
 
     final CustomField customField_two = postWithStatus(CUSTOM_FIELDS_PATH, cfWithAccentName, SC_CREATED, USER8)
       .as(CustomField.class);
-    assertEquals("this-is-a_1", customField_one.getId());
-    assertEquals("this-is-a-tricky-string_1", customField_two.getId());
+    assertEquals("this-is-a_1", customField_one.getRefId());
+    assertEquals("this-is-a-tricky-string_1", customField_two.getRefId());
   }
 
   @Test
   public void shouldNotCreateCustomFieldWhenNameIsTooLong() throws IOException, URISyntaxException {
     final String cfWithHalfName = readFile("fields/post/postCustomNameWithTooLongName.json");
-    postWithStatus(CUSTOM_FIELDS_PATH, cfWithHalfName, SC_CREATED, USER8);
+//    postWithStatus(CUSTOM_FIELDS_PATH, cfWithHalfName, SC_CREATED, USER8);
+    postWithStatus(CUSTOM_FIELDS_PATH, cfWithHalfName, SC_UNPROCESSABLE_ENTITY, USER8);
   }
 
   @Test
@@ -209,12 +210,14 @@ public class CustomFieldsImplTest extends TestBase {
 
   @Test
   public void shouldReturnFieldOnValidId() throws IOException, URISyntaxException {
-    createFields();
+    final CustomField customField =
+      postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8)
+        .as(CustomField.class);
 
-    CustomField  field = getWithOk(CUSTOM_FIELDS_ID_PATH).as(CustomField.class);
+    CustomField  field = getWithOk(CUSTOM_FIELDS_PATH + "/" + customField.getId()).as(CustomField.class);
 
     assertEquals("Department", field.getName());
-    assertEquals(FIELD_ID, field.getId());
+    assertEquals("department_1", field.getRefId());
     assertEquals("Provide a department", field.getHelpText());
     assertEquals(true, field.getRequired());
     assertEquals(true, field.getVisible());
@@ -229,7 +232,7 @@ public class CustomFieldsImplTest extends TestBase {
   public void getCustomFieldsById() throws IOException, URISyntaxException {
     final String postField = readFile("fields/post/postCustomField.json");
 
-    DBTestUtil.insertCustomField(vertx, FIELD_ID, STUB_TENANT, postField);
+    DBTestUtil.insertCustomField(vertx, STUB_FIELD_ID, STUB_TENANT, postField);
 
     CustomField field = getWithOk(CUSTOM_FIELDS_ID_PATH).as(CustomField.class);
 
@@ -243,12 +246,15 @@ public class CustomFieldsImplTest extends TestBase {
 
   @Test
   public void shouldUpdateNoteNameTypeOnPut() throws IOException, URISyntaxException {
-    postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8);
-    putWithNoContent(CUSTOM_FIELDS_ID_PATH, readFile("fields/post/putCustomField.json"), USER9);
+
+    final CustomField customField =
+      postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8)
+        .as(CustomField.class);
+    putWithNoContent(CUSTOM_FIELDS_PATH + "/" + customField.getId(), readFile("fields/put/putCustomField.json"), USER9);
 
     CustomField field = CustomFieldsDBTestUtil.getAllCustomFields(vertx).get(0);
     assertEquals("Department 2", field.getName());
-    assertEquals(FIELD_ID, field.getId());
+    assertEquals("department-_1", field.getRefId());
     assertEquals("Provide a second department", field.getHelpText());
     assertEquals(false, field.getRequired());
     assertEquals(false, field.getVisible());
@@ -263,15 +269,69 @@ public class CustomFieldsImplTest extends TestBase {
     assertEquals("mockuser9", noteTypeMetadata.getUpdatedByUsername());
   }
 
+  public void shouldNotChangeRefIdWhenNameIsSameOnPut() throws IOException, URISyntaxException {
+    final CustomField customField =
+      postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField2.json"), SC_CREATED, USER8)
+        .as(CustomField.class);
+    putWithNoContent(CUSTOM_FIELDS_PATH + "/" + customField.getId(), readFile("fields/put/putCustomField2.json"), USER9);
+
+    CustomField field = CustomFieldsDBTestUtil.getAllCustomFields(vertx).get(0);
+    assertEquals("Expiration Date", field.getName());
+    assertEquals("expiration-date_1", field.getRefId());
+    assertEquals("Set expiration date", field.getHelpText());
+    assertEquals(true, field.getRequired());
+    assertEquals(true, field.getVisible());
+    assertEquals(CustomField.Type.SINGLE_CHECKBOX, field.getType());
+
+    final Metadata noteTypeMetadata = field.getMetadata();
+
+    assertEquals(USER8.getValue(), noteTypeMetadata.getCreatedByUserId());
+    assertEquals("m8", noteTypeMetadata.getCreatedByUsername());
+
+    assertEquals(USER9.getValue(), noteTypeMetadata.getUpdatedByUserId());
+    assertEquals("mockuser9", noteTypeMetadata.getUpdatedByUsername());
+  }
+
   @Test
-  public void deleteCustomFieldsById() {
-    deleteWithStatus(CUSTOM_FIELDS_ID_PATH, SC_NOT_IMPLEMENTED);
+  public void deleteCustomFieldsById() throws IOException, URISyntaxException {
+    final CustomField customFieldOne = postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8)
+      .as(CustomField.class);
+
+    deleteWithNoContent(CUSTOM_FIELDS_PATH + "/" + customFieldOne.getId());
+    deleteWithStatus(CUSTOM_FIELDS_ID_PATH, SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturn404WhenDeleteRequestHasNotExistingUUID() {
+    deleteWithStatus(CUSTOM_FIELDS_PATH + "/11111111-2222-3333-a444-555555555555", SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldReturn400WhenDeleteRequestHasInvalidUUID() {
+    deleteWithStatus(CUSTOM_FIELDS_PATH + "/11111111-3-1111-333-111111111111", SC_BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldDeleteAndGenerateNewRefId() throws IOException, URISyntaxException {
+    final CustomField customFieldOne = postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8)
+      .as(CustomField.class);
+
+    postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8);
+
+    deleteWithNoContent(CUSTOM_FIELDS_PATH + "/" + customFieldOne.getId());
+
+    final CustomField customFieldThree =
+      postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8)
+        .as(CustomField.class);
+
+    assertTrue(customFieldThree.getRefId().endsWith("_3"));
+
   }
 
   private void createFields() throws IOException, URISyntaxException {
     CustomField postField2 = readJsonFile("fields/post/postCustomField2.json", CustomField.class);
     CustomField postField = readJsonFile("fields/post/postCustomField.json", CustomField.class);
-    CustomFieldsDBTestUtil.saveCustomField(FIELD_ID, postField, vertx);
-    CustomFieldsDBTestUtil.saveCustomField(FIELD_ID_2, postField2, vertx);
+    CustomFieldsDBTestUtil.saveCustomField(STUB_FIELD_ID, postField, vertx);
+    CustomFieldsDBTestUtil.saveCustomField(STUB_FIELD_ID_2, postField2, vertx);
   }
 }

--- a/src/test/resources/fields/post/postCustomField.json
+++ b/src/test/resources/fields/post/postCustomField.json
@@ -1,7 +1,7 @@
 {
   "name": "Department",
-  "id": "department_1",
   "type" : "SINGLE_CHECKBOX",
+  "refId": "not-null-ref-id",
   "visible": true,
   "required": true,
   "helpText": "Provide a department"

--- a/src/test/resources/fields/put/putCustomField.json
+++ b/src/test/resources/fields/put/putCustomField.json
@@ -1,0 +1,7 @@
+{
+  "name": "Department 2",
+  "type" : "RADIO_BUTTON",
+  "visible": false,
+  "required": false,
+  "helpText": "Provide a second department"
+}

--- a/src/test/resources/fields/put/putCustomField2.json
+++ b/src/test/resources/fields/put/putCustomField2.json
@@ -1,7 +1,6 @@
 {
   "name": "Expiration Date",
-  "type" : "TEXTBOX_SHORT",
-  "refId": "not-null-ref-id",
+  "type" : "SINGLE_CHECKBOX",
   "visible": true,
   "required": true,
   "helpText": "Set expiration date"


### PR DESCRIPTION
## Purpose
Due to https://issues.folio.org/browse/MODCFIELDS-8 we want to be able to delete a custom field.

## Approach
* added implementation for the DELETE /custom-field{id}
* added tests
* updated custom field schema with id as a unique identifier
* updated the reference id generation
* added reference id generation on PUT /custom-fields{id}
* added trigger on update custom field which will replace an old refId if custom field name was not changed during the PUT(instead of an additional call to db to compare names)

## Learn
* [Rostgres regex](https://www.postgresql.org/docs/9.3/functions-matching.html) used for selecting all names by pattern
* [Postgres unnest](https://www.postgresql.org/docs/9.2/functions-array.html) used to transform a row array to set of rows

The main changes are done in commits:
f5680b2 
51f8b89
540d0f2

