### PR TITLE
MODCFIELDS-24: Validate that only allowed attributes are present for given type

### DIFF
--- a/src/main/java/org/folio/validate/TextFieldValidator.java
+++ b/src/main/java/org/folio/validate/TextFieldValidator.java
@@ -14,7 +14,7 @@ public class TextFieldValidator implements CustomFieldValidator {
   public void validate(Object fieldValue, CustomField fieldDefinition) {
     Validate.isInstanceOf(String.class, fieldValue, "Text field must be a string");
     Integer maxSize = fieldDefinition.getTextField().getMaxSize();
-    Validate.isTrue(fieldValue.toString().length() <= maxSize, "Maximum length of short text box field is %s" , maxSize);
+    Validate.isTrue(fieldValue.toString().length() <= maxSize, "Maximum length of this text field is %s" , maxSize);
   }
 
   @Override

--- a/src/main/java/org/folio/validate/ValidationServiceImpl.java
+++ b/src/main/java/org/folio/validate/ValidationServiceImpl.java
@@ -3,10 +3,12 @@ package org.folio.validate;
 import static org.folio.validate.ValidationUtil.createError;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.Error;
@@ -66,9 +68,9 @@ public class ValidationServiceImpl implements ValidationService {
   private List<Error> validate(Object fieldValue, CustomField fieldDefinition) {
     return validators.stream()
       .filter(validator -> validator.supportedTypes().contains(fieldDefinition.getType()))
-      .findFirst()
       .map(validator -> validate(fieldValue, fieldDefinition, validator))
-      .orElse(Collections.emptyList());
+      .flatMap(Collection::stream)
+      .collect(Collectors.toList());
   }
 
   private List<Error> validate(Object fieldValue, CustomField fieldDefinition, CustomFieldValidator validator) {

--- a/src/main/java/org/folio/validate/definition/AllowedFieldsConstants.java
+++ b/src/main/java/org/folio/validate/definition/AllowedFieldsConstants.java
@@ -1,0 +1,31 @@
+package org.folio.validate.definition;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+public class AllowedFieldsConstants {
+  public static final Set<String> COMMON_ALLOWED_FIELDS = ImmutableSet.of(
+    "id",
+    "name",
+    "refId",
+    "type",
+    "entityType",
+    "visible",
+    "required",
+    "helpText",
+    "metadata"
+  );
+
+  public static final Set<String> CHECKBOX_ALLOWED_FIELDS = new ImmutableSet.Builder<String>()
+    .addAll(COMMON_ALLOWED_FIELDS).add("checkboxField")
+    .build();
+  public static final Set<String> TEXT_ALLOWED_FIELDS = new ImmutableSet.Builder<String>()
+    .addAll(COMMON_ALLOWED_FIELDS).add("textField")
+    .build();
+  public static final Set<String> SELECT_ALLOWED_FIELDS = new ImmutableSet.Builder<String>()
+    .addAll(COMMON_ALLOWED_FIELDS).add("selectField")
+    .build();
+
+}
+

--- a/src/main/java/org/folio/validate/definition/CheckboxDefinitionValidator.java
+++ b/src/main/java/org/folio/validate/definition/CheckboxDefinitionValidator.java
@@ -1,0 +1,19 @@
+package org.folio.validate.definition;
+
+import static org.folio.validate.definition.AllowedFieldsConstants.CHECKBOX_ALLOWED_FIELDS;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CheckboxDefinitionValidator implements Validatable {
+  @Override
+  public void validateDefinition(CustomField fieldDefinition) {
+    CustomDefinitionValidationUtil.onlyHasAllowedFields(fieldDefinition, CHECKBOX_ALLOWED_FIELDS);
+  }
+
+  @Override
+  public boolean isApplicable(CustomField fieldDefinition) {
+    return CustomField.Type.SINGLE_SELECT_DROPDOWN.equals(fieldDefinition.getType());
+  }
+}

--- a/src/main/java/org/folio/validate/definition/CustomDefinitionValidationUtil.java
+++ b/src/main/java/org/folio/validate/definition/CustomDefinitionValidationUtil.java
@@ -1,0 +1,44 @@
+package org.folio.validate.definition;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.folio.rest.jaxrs.model.CustomField;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class CustomDefinitionValidationUtil {
+
+  /**
+   * Throws exception if customField has non-null fields that are not in allowedFields collection
+   * @param customField validated custom field definition
+   * @param allowedFields field that can be not null
+   * @throws IllegalArgumentException if falidation fails
+   */
+  public static void onlyHasAllowedFields(CustomField customField, Collection<String> allowedFields){
+    List<Field> properties = FieldUtils.getFieldsListWithAnnotation(CustomField.class, JsonProperty.class);
+    for (Field property : properties) {
+      Validate.isTrue(isAllowedOrNull(property, customField, allowedFields),
+        "Attribute %s is not allowed, following attributes are allowed for field of type %s : %s",
+      property.getName(), customField.getType(), allowedFields);
+    }
+  }
+
+  private static boolean isAllowedOrNull(Field property, CustomField customField, Collection<String> allowedFields) {
+    return allowedFields.contains(property.getName()) || Objects.isNull(getFieldValue(customField, property));
+  }
+
+  private static Object getFieldValue(CustomField customField, Field field) {
+    try {
+      return FieldUtils.readField(field, customField, true);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/src/main/java/org/folio/validate/definition/MultiSelectDefinitionValidator.java
+++ b/src/main/java/org/folio/validate/definition/MultiSelectDefinitionValidator.java
@@ -1,0 +1,19 @@
+package org.folio.validate.definition;
+
+import static org.folio.validate.definition.AllowedFieldsConstants.SELECT_ALLOWED_FIELDS;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MultiSelectDefinitionValidator implements Validatable {
+  @Override
+  public void validateDefinition(CustomField fieldDefinition) {
+    CustomDefinitionValidationUtil.onlyHasAllowedFields(fieldDefinition, SELECT_ALLOWED_FIELDS);
+  }
+
+  @Override
+  public boolean isApplicable(CustomField fieldDefinition) {
+    return CustomField.Type.MULTI_SELECT_DROPDOWN.equals(fieldDefinition.getType());
+  }
+}

--- a/src/main/java/org/folio/validate/definition/SingleSelectDefinitionValidator.java
+++ b/src/main/java/org/folio/validate/definition/SingleSelectDefinitionValidator.java
@@ -1,0 +1,19 @@
+package org.folio.validate.definition;
+
+import static org.folio.validate.definition.AllowedFieldsConstants.SELECT_ALLOWED_FIELDS;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SingleSelectDefinitionValidator implements Validatable {
+  @Override
+  public void validateDefinition(CustomField fieldDefinition) {
+    CustomDefinitionValidationUtil.onlyHasAllowedFields(fieldDefinition, SELECT_ALLOWED_FIELDS);
+  }
+
+  @Override
+  public boolean isApplicable(CustomField fieldDefinition) {
+    return CustomField.Type.SINGLE_SELECT_DROPDOWN.equals(fieldDefinition.getType());
+  }
+}

--- a/src/main/java/org/folio/validate/definition/TextFieldDefinitionValidator.java
+++ b/src/main/java/org/folio/validate/definition/TextFieldDefinitionValidator.java
@@ -1,0 +1,20 @@
+package org.folio.validate.definition;
+
+import static org.folio.validate.definition.AllowedFieldsConstants.TEXT_ALLOWED_FIELDS;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TextFieldDefinitionValidator implements Validatable{
+  @Override
+  public void validateDefinition(CustomField fieldDefinition) {
+    CustomDefinitionValidationUtil.onlyHasAllowedFields(fieldDefinition, TEXT_ALLOWED_FIELDS);
+  }
+
+  @Override
+  public boolean isApplicable(CustomField fieldDefinition) {
+    return CustomField.Type.TEXTBOX_SHORT.equals(fieldDefinition.getType()) ||
+           CustomField.Type.TEXTBOX_LONG.equals(fieldDefinition.getType());
+  }
+}

--- a/src/test/java/org/folio/validate/definition/CheckboxDefinitionValidatorTest.java
+++ b/src/test/java/org/folio/validate/definition/CheckboxDefinitionValidatorTest.java
@@ -1,0 +1,36 @@
+package org.folio.validate.definition;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.TextField;
+import org.folio.spring.TestConfiguration;
+import org.folio.test.util.TestUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TestConfiguration.class)
+public class CheckboxDefinitionValidatorTest {
+
+  @Autowired
+  private CheckboxDefinitionValidator validator;
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  @Test
+  public void shouldReturnErrorIfContainsNotAllowedFields() throws IOException, URISyntaxException {
+    expectedEx.expect(IllegalArgumentException.class);
+    expectedEx.expectMessage("Attribute textField is not allowed");
+    final CustomField customField = TestUtil.readJsonFile(
+      "fields/post/checkbox/postCheckbox.json", CustomField.class);
+    customField.setTextField(new TextField());
+    validator.validateDefinition(customField);
+  }
+}

--- a/src/test/resources/fields/post/checkbox/postCheckbox.json
+++ b/src/test/resources/fields/post/checkbox/postCheckbox.json
@@ -1,0 +1,11 @@
+{
+  "name": "Is student",
+  "visible": true,
+  "required": true,
+  "type": "SINGLE_CHECKBOX",
+  "entityType": "user",
+  "helpText": "Check if user is a student",
+  "checkboxField" : {
+    "default" : true
+  }
+}


### PR DESCRIPTION
## Purpose
Make sure that structure of request makes sense for the type of custom fields (e.g. make sure that checkbox field doesn't have "textField" attribute)

## Approach
Use reflection to check that all attributes that are not related to the
given custom field type are set to null in POST and PUT request