### PR TITLE
Custom Fields: Support fields order on POST /custom-fields

### DIFF
--- a/ramls/customField.json
+++ b/ramls/customField.json
@@ -40,6 +40,11 @@
       "description": "Defines if the custom field is required",
       "example": true
     },
+    "order": {
+      "type": "integer",
+      "description": "Еhe order of the custom field to be displayed",
+      "example": 1
+    },
     "helpText": {
       "type": "string",
       "description": "The description of the custom field",
@@ -69,6 +74,7 @@
   "required": [
     "name",
     "type",
-    "entityType"
+    "entityType",
+    "order"
   ]
 }

--- a/src/main/java/org/folio/repository/CustomFieldsConstants.java
+++ b/src/main/java/org/folio/repository/CustomFieldsConstants.java
@@ -8,4 +8,6 @@ public class CustomFieldsConstants {
 
   public static final String REF_ID_REGEX = "(%s_[1-9]{1,})";
   static final String SELECT_REF_IDS = "SELECT unnest(regexp_matches(" + JSONB_COLUMN + " ->> 'refId', ?)) as values FROM %s";
+
+  public static final String FIND_CF_BY_ORDER_QUERY = "query=order==%d";
 }

--- a/src/main/java/org/folio/repository/CustomFieldsRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/CustomFieldsRepositoryImpl.java
@@ -138,4 +138,8 @@ public class CustomFieldsRepositoryImpl implements CustomFieldsRepository {
       .withCustomFields(results.getResults())
       .withTotalRecords(results.getResultInfo().getTotalRecords());
   }
+
+  private Long mapCount(ResultSet resultSet) {
+    return resultSet.getRows().get(0).getLong("count");
+  }
 }

--- a/src/main/java/org/folio/rest/exceptions/CustomFieldOrderExceptionHandler.java
+++ b/src/main/java/org/folio/rest/exceptions/CustomFieldOrderExceptionHandler.java
@@ -1,0 +1,34 @@
+package org.folio.rest.exceptions;
+
+import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
+
+import static org.folio.common.pf.PartialFunctions.pf;
+import static org.folio.rest.exc.ExceptionPredicates.instanceOf;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.common.pf.PartialFunction;
+import org.folio.rest.ResponseHelper;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.validate.ValidationUtil;
+
+public class CustomFieldOrderExceptionHandler {
+
+  private CustomFieldOrderExceptionHandler() {}
+
+  public static PartialFunction<Throwable, Response> customFieldOrderValidationHandler() {
+    return pf(instanceOf(IllegalArgumentException.class)
+        .and(throwable -> {
+          IllegalArgumentException exc = (IllegalArgumentException) throwable;
+          return "Order number should be unique.".equals(exc.getMessage());
+        })
+      , CustomFieldOrderExceptionHandler::toUnprocessableEntity);
+  }
+
+  private static Response toUnprocessableEntity(Throwable t) {
+    IllegalArgumentException exc = (IllegalArgumentException) t;
+    final Error errorMessage = ValidationUtil.createError(
+      null, null, exc.getMessage());
+    return ResponseHelper.statusWithJson(SC_UNPROCESSABLE_ENTITY, errorMessage);
+  }
+}

--- a/src/main/java/org/folio/spring/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/ApplicationConfig.java
@@ -7,6 +7,7 @@ import static org.folio.rest.exc.RestExceptionHandlers.baseUnprocessableHandler;
 import static org.folio.rest.exc.RestExceptionHandlers.completionCause;
 import static org.folio.rest.exc.RestExceptionHandlers.generalHandler;
 import static org.folio.rest.exc.RestExceptionHandlers.logged;
+import static org.folio.rest.exceptions.CustomFieldOrderExceptionHandler.customFieldOrderValidationHandler;
 import static org.folio.rest.exceptions.CustomFieldTypeExceptionHandler.customFieldTypeValidationHandler;
 
 import java.util.Collection;
@@ -47,6 +48,7 @@ public class ApplicationConfig {
       .orElse(baseNotFoundHandler())
       .orElse(baseUnauthorizedHandler())
       .orElse(customFieldTypeValidationHandler())
+      .orElse(customFieldOrderValidationHandler())
       .orElse(baseUnprocessableHandler())
       .orElse(generalHandler())
       .compose(completionCause()));

--- a/src/main/java/org/folio/validate/definition/AllowedFieldsConstants.java
+++ b/src/main/java/org/folio/validate/definition/AllowedFieldsConstants.java
@@ -13,6 +13,7 @@ public class AllowedFieldsConstants {
     "entityType",
     "visible",
     "required",
+    "order",
     "helpText",
     "metadata"
   );

--- a/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
@@ -38,6 +38,7 @@ import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.CustomFieldCollection;
 import org.folio.rest.jaxrs.model.CustomFieldStatisticCollection;
+import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.test.util.TestBase;
 
@@ -105,8 +106,8 @@ public class CustomFieldsImplTest extends TestBase {
     final String cfWithAccentName = readFile("fields/post/postCustomFieldWithAccentName.json");
     final CustomField customField_one = postWithStatus(CUSTOM_FIELDS_PATH, cfWithAccentName, SC_CREATED, USER8)
       .as(CustomField.class);
-
-    final CustomField customField_two = postWithStatus(CUSTOM_FIELDS_PATH, cfWithAccentName, SC_CREATED, USER8)
+    final String cfWithAccentName2 = readFile("fields/post/postCustomFieldWithAccentNameSecond.json");
+    final CustomField customField_two = postWithStatus(CUSTOM_FIELDS_PATH, cfWithAccentName2, SC_CREATED, USER8)
       .as(CustomField.class);
     assertEquals("this-is-a-tricky-string_1", customField_one.getRefId());
     assertEquals("this-is-a-tricky-string_2", customField_two.getRefId());
@@ -114,8 +115,8 @@ public class CustomFieldsImplTest extends TestBase {
 
   @Test
   public void shouldCreateTwoRefIdOnPostCustomFieldWithSameName2() throws IOException, URISyntaxException {
-    final String cfWithHalfName = readFile("fields/post/postCustomFieldHalfName.json");
     final String cfWithAccentName = readFile("fields/post/postCustomFieldWithAccentName.json");
+    final String cfWithHalfName = readFile("fields/post/postCustomFieldHalfName2.json");
     final CustomField customField_one = postWithStatus(CUSTOM_FIELDS_PATH, cfWithHalfName, SC_CREATED, USER8)
       .as(CustomField.class);
 
@@ -262,6 +263,16 @@ public class CustomFieldsImplTest extends TestBase {
   }
 
   @Test
+  public void shouldReturn422ErrorWhenOrderIsInvalid() throws IOException, URISyntaxException {
+    String customFieldFile = readFile("fields/post/postCustomField.json");
+
+    postWithStatus(CUSTOM_FIELDS_PATH, customFieldFile, SC_CREATED, USER8);
+    final Error error = postWithStatus(CUSTOM_FIELDS_PATH, customFieldFile, SC_UNPROCESSABLE_ENTITY, USER8).as(Error.class);
+
+    assertEquals("Order number should be unique.", error.getMessage());
+  }
+
+  @Test
   public void shouldReturn404OnMissingId() {
     getWithStatus(CUSTOM_FIELDS_ID_PATH, SC_NOT_FOUND);
   }
@@ -394,7 +405,7 @@ public class CustomFieldsImplTest extends TestBase {
     final CustomField customFieldOne = postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8)
       .as(CustomField.class);
 
-    postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomField.json"), SC_CREATED, USER8);
+    postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/post/postCustomFieldOrder2.json"), SC_CREATED, USER8);
 
     deleteWithNoContent(CUSTOM_FIELDS_PATH + "/" + customFieldOne.getId());
 

--- a/src/test/resources/fields/post/multiSelect/postWithDefaultsMoreThanOptions.json
+++ b/src/test/resources/fields/post/multiSelect/postWithDefaultsMoreThanOptions.json
@@ -5,6 +5,7 @@
   "type": "MULTI_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes", "icecream"],
     "multiSelect" : true,

--- a/src/test/resources/fields/post/multiSelect/postWithDuplicatesInDefaults.json
+++ b/src/test/resources/fields/post/multiSelect/postWithDuplicatesInDefaults.json
@@ -5,6 +5,7 @@
   "type": "MULTI_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes", "potatoes"],
     "multiSelect" : true,

--- a/src/test/resources/fields/post/multiSelect/postWithInvalidDefaulsValues.json
+++ b/src/test/resources/fields/post/multiSelect/postWithInvalidDefaulsValues.json
@@ -5,6 +5,7 @@
   "type": "MULTI_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes", "icecream"],
     "multiSelect" : true,

--- a/src/test/resources/fields/post/multiSelect/postWithInvalidMultiSelectValue.json
+++ b/src/test/resources/fields/post/multiSelect/postWithInvalidMultiSelectValue.json
@@ -5,6 +5,7 @@
   "type": "MULTI_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/multiSelect/postWithInvalidSizeOptions.json
+++ b/src/test/resources/fields/post/multiSelect/postWithInvalidSizeOptions.json
@@ -5,6 +5,7 @@
   "type": "MULTI_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : true,

--- a/src/test/resources/fields/post/multiSelect/postWithMultiSelectValueNotDefined.json
+++ b/src/test/resources/fields/post/multiSelect/postWithMultiSelectValueNotDefined.json
@@ -5,6 +5,7 @@
   "type": "MULTI_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes"],
     "options" :  {

--- a/src/test/resources/fields/post/multiSelect/postWithOptionNameTooLong.json
+++ b/src/test/resources/fields/post/multiSelect/postWithOptionNameTooLong.json
@@ -5,6 +5,7 @@
   "type": "MULTI_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : true,

--- a/src/test/resources/fields/post/multiSelect/postWithSelectFieldNotDefined.json
+++ b/src/test/resources/fields/post/multiSelect/postWithSelectFieldNotDefined.json
@@ -4,5 +4,6 @@
   "required": true,
   "type": "MULTI_SELECT_DROPDOWN",
   "entityType": "user",
-  "helpText": "Choose your favorite food"
+  "helpText": "Choose your favorite food",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomField2.json
+++ b/src/test/resources/fields/post/postCustomField2.json
@@ -5,5 +5,6 @@
   "visible": true,
   "required": true,
   "entityType": "package",
-  "helpText": "Set expiration date"
+  "helpText": "Set expiration date",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomFieldEmptyEntityType.json
+++ b/src/test/resources/fields/post/postCustomFieldEmptyEntityType.json
@@ -3,5 +3,6 @@
   "visible": true,
   "required": true,
   "type": "SINGLE_CHECKBOX",
-  "helpText": "Provide a department"
+  "helpText": "Provide a department",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomFieldEmptyName.json
+++ b/src/test/resources/fields/post/postCustomFieldEmptyName.json
@@ -3,5 +3,6 @@
   "required": true,
   "type": "SINGLE_CHECKBOX",
   "entityType": "user",
-  "helpText": "Provide a department"
+  "helpText": "Provide a department",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomFieldEmptyType.json
+++ b/src/test/resources/fields/post/postCustomFieldEmptyType.json
@@ -3,5 +3,6 @@
   "visible": true,
   "required": true,
   "entityType": "user",
-  "helpText": "Provide a department"
+  "helpText": "Provide a department",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomFieldHalfName.json
+++ b/src/test/resources/fields/post/postCustomFieldHalfName.json
@@ -4,5 +4,6 @@
   "required": true,
   "type": "SINGLE_CHECKBOX",
   "entityType": "user",
-  "helpText": "Provide a department"
+  "helpText": "Provide a department",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomFieldHalfName2.json
+++ b/src/test/resources/fields/post/postCustomFieldHalfName2.json
@@ -1,10 +1,9 @@
 {
-  "name": "Department",
-  "type" : "SINGLE_CHECKBOX",
-  "refId": "not-null-ref-id",
+  "name": "Tĥïŝ12 ĩš?] â",
   "visible": true,
   "required": true,
+  "type": "SINGLE_CHECKBOX",
   "entityType": "user",
   "helpText": "Provide a department",
-  "order": 1
+  "order": 2
 }

--- a/src/test/resources/fields/post/postCustomFieldHelpTextInvalid.json
+++ b/src/test/resources/fields/post/postCustomFieldHelpTextInvalid.json
@@ -4,5 +4,6 @@
   "required": true,
   "type": "RADIO_BUTTON",
   "entityType": "user",
-  "helpText": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus."
+  "helpText": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus.",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomFieldOrder2.json
+++ b/src/test/resources/fields/post/postCustomFieldOrder2.json
@@ -6,5 +6,5 @@
   "required": true,
   "entityType": "user",
   "helpText": "Provide a department",
-  "order": 1
+  "order": 2
 }

--- a/src/test/resources/fields/post/postCustomFieldWithAccentName.json
+++ b/src/test/resources/fields/post/postCustomFieldWithAccentName.json
@@ -4,5 +4,6 @@
   "required": true,
   "type": "SINGLE_CHECKBOX",
   "entityType": "user",
-  "helpText": "Provide a department"
+  "helpText": "Provide a department",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomFieldWithAccentName2.json
+++ b/src/test/resources/fields/post/postCustomFieldWithAccentName2.json
@@ -4,5 +4,6 @@
   "required": true,
   "type": "SINGLE_CHECKBOX",
   "entityType": "user",
-  "helpText": "Provide a department"
+  "helpText": "Provide a department",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postCustomFieldWithAccentNameSecond.json
+++ b/src/test/resources/fields/post/postCustomFieldWithAccentNameSecond.json
@@ -1,10 +1,9 @@
 {
-  "name": "Department",
-  "type" : "SINGLE_CHECKBOX",
-  "refId": "not-null-ref-id",
+  "name": "Tĥïŝ ĩš â ťŕĭçķŷ Šťŕĭńġ",
   "visible": true,
   "required": true,
+  "type": "SINGLE_CHECKBOX",
   "entityType": "user",
   "helpText": "Provide a department",
-  "order": 1
+  "order": 2
 }

--- a/src/test/resources/fields/post/postCustomNameWithTooLongName.json
+++ b/src/test/resources/fields/post/postCustomNameWithTooLongName.json
@@ -4,5 +4,6 @@
   "required": true,
   "type": "RADIO_BUTTON",
   "entityType": "user",
-  "helpText": "Provide a department"
+  "helpText": "Provide a department",
+  "order": 1
 }

--- a/src/test/resources/fields/post/postInvalidCustomField.json
+++ b/src/test/resources/fields/post/postInvalidCustomField.json
@@ -5,5 +5,6 @@
   "visible": true,
   "required": true,
   "entityType": "user",
-  "helpText": "Provide a department"
+  "helpText": "Provide a department",
+  "order": 1
 }

--- a/src/test/resources/fields/post/radioButton/postCustomFieldRadioButton.json
+++ b/src/test/resources/fields/post/radioButton/postCustomFieldRadioButton.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithDefaultIsNull.json
+++ b/src/test/resources/fields/post/radioButton/postWithDefaultIsNull.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : null,
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithDefaultSizeMoreThanDefined.json
+++ b/src/test/resources/fields/post/radioButton/postWithDefaultSizeMoreThanDefined.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs", "pizza", "potatoes", "pie", "barbeque", "icecream"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithDefaultsEmpty.json
+++ b/src/test/resources/fields/post/radioButton/postWithDefaultsEmpty.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : [],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithEmptyOptions.json
+++ b/src/test/resources/fields/post/radioButton/postWithEmptyOptions.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithInvalidDefaultValue.json
+++ b/src/test/resources/fields/post/radioButton/postWithInvalidDefaultValue.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs-with-mushrooms"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithInvalidDefaultValues.json
+++ b/src/test/resources/fields/post/radioButton/postWithInvalidDefaultValues.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["icecream"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithInvalidDefaults.json
+++ b/src/test/resources/fields/post/radioButton/postWithInvalidDefaults.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs", "pizza"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithInvalidDefaultsSize.json
+++ b/src/test/resources/fields/post/radioButton/postWithInvalidDefaultsSize.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs", "pizza"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithInvalidMultiSelectValue.json
+++ b/src/test/resources/fields/post/radioButton/postWithInvalidMultiSelectValue.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes"],
     "multiSelect" : true,

--- a/src/test/resources/fields/post/radioButton/postWithInvalidOptionName.json
+++ b/src/test/resources/fields/post/radioButton/postWithInvalidOptionName.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithInvalidSizeOptions.json
+++ b/src/test/resources/fields/post/radioButton/postWithInvalidSizeOptions.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithMultiSelectValueNotDefined.json
+++ b/src/test/resources/fields/post/radioButton/postWithMultiSelectValueNotDefined.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes"],
     "options" :  {

--- a/src/test/resources/fields/post/radioButton/postWithOptionNullValues.json
+++ b/src/test/resources/fields/post/radioButton/postWithOptionNullValues.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : [],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/radioButton/postWithSelectFieldNotDefined.json
+++ b/src/test/resources/fields/post/radioButton/postWithSelectFieldNotDefined.json
@@ -4,5 +4,6 @@
   "required": true,
   "type": "RADIO_BUTTON",
   "entityType": "user",
-  "helpText": "Choose your favorite food"
+  "helpText": "Choose your favorite food",
+  "order": 1
 }

--- a/src/test/resources/fields/post/radioButton/postWithoutOptions.json
+++ b/src/test/resources/fields/post/radioButton/postWithoutOptions.json
@@ -5,6 +5,7 @@
   "type": "RADIO_BUTTON",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : false

--- a/src/test/resources/fields/post/singleSelect/postInvalidDefaultsSize.json
+++ b/src/test/resources/fields/post/singleSelect/postInvalidDefaultsSize.json
@@ -5,6 +5,7 @@
   "type": "SINGLE_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs", "pizza"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/singleSelect/postWithDefaultsMoreThanOptions.json
+++ b/src/test/resources/fields/post/singleSelect/postWithDefaultsMoreThanOptions.json
@@ -5,6 +5,7 @@
   "type": "SINGLE_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes", "icecream"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/singleSelect/postWithInvalidDefaulsValues.json
+++ b/src/test/resources/fields/post/singleSelect/postWithInvalidDefaulsValues.json
@@ -5,6 +5,7 @@
   "type": "SINGLE_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["icecream"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/singleSelect/postWithInvalidMultiSelectValue.json
+++ b/src/test/resources/fields/post/singleSelect/postWithInvalidMultiSelectValue.json
@@ -5,6 +5,7 @@
   "type": "SINGLE_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes"],
     "multiSelect" : true,

--- a/src/test/resources/fields/post/singleSelect/postWithInvalidOptionsSize.json
+++ b/src/test/resources/fields/post/singleSelect/postWithInvalidOptionsSize.json
@@ -5,6 +5,7 @@
   "type": "SINGLE_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/singleSelect/postWithMultiSelectValueNotDefined.json
+++ b/src/test/resources/fields/post/singleSelect/postWithMultiSelectValueNotDefined.json
@@ -5,6 +5,7 @@
   "type": "SINGLE_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["potatoes"],
     "options" :  {

--- a/src/test/resources/fields/post/singleSelect/postWithOptionNameTooLong.json
+++ b/src/test/resources/fields/post/singleSelect/postWithOptionNameTooLong.json
@@ -5,6 +5,7 @@
   "type": "SINGLE_SELECT_DROPDOWN",
   "entityType": "user",
   "helpText": "Choose your favorite food",
+  "order": 1,
   "selectField" : {
     "defaults" : ["eggs"],
     "multiSelect" : false,

--- a/src/test/resources/fields/post/singleSelect/postWithSelectFieldNotDefined.json
+++ b/src/test/resources/fields/post/singleSelect/postWithSelectFieldNotDefined.json
@@ -4,5 +4,6 @@
   "required": true,
   "type": "SINGLE_SELECT_DROPDOWN",
   "entityType": "user",
-  "helpText": "Choose your favorite food"
+  "helpText": "Choose your favorite food",
+  "order": 1
 }

--- a/src/test/resources/fields/put/putCustomField.json
+++ b/src/test/resources/fields/put/putCustomField.json
@@ -5,6 +5,7 @@
   "required": false,
   "entityType": "user",
   "helpText": "Provide a second department",
+  "order": 1,
   "checkboxField" : {
     "default" : true
   }

--- a/src/test/resources/fields/put/putCustomField2.json
+++ b/src/test/resources/fields/put/putCustomField2.json
@@ -4,5 +4,6 @@
   "visible": true,
   "required": true,
   "entityType": "user",
-  "helpText": "Set expiration date"
+  "helpText": "Set expiration date",
+  "order": 1
 }

--- a/src/test/resources/fields/put/putCustomFieldEmptyEntityType.json
+++ b/src/test/resources/fields/put/putCustomFieldEmptyEntityType.json
@@ -3,5 +3,6 @@
   "type" : "RADIO_BUTTON",
   "visible": false,
   "required": false,
-  "helpText": "Provide a second department"
+  "helpText": "Provide a second department",
+  "order": 1
 }

--- a/src/test/resources/fields/put/putCustomFieldEmptyName.json
+++ b/src/test/resources/fields/put/putCustomFieldEmptyName.json
@@ -3,5 +3,6 @@
   "visible": false,
   "required": false,
   "entityType": "user",
-  "helpText": "Provide a second department"
+  "helpText": "Provide a second department",
+  "order": 1
 }

--- a/src/test/resources/fields/put/putCustomFieldEmptyType.json
+++ b/src/test/resources/fields/put/putCustomFieldEmptyType.json
@@ -3,5 +3,6 @@
   "visible": false,
   "required": false,
   "entityType": "user",
-  "helpText": "Provide a second department"
+  "helpText": "Provide a second department",
+  "order": 1
 }


### PR DESCRIPTION
## Purpose
Per MODCFIELDS-25 introduce the `order` property for custom fields and extend POST /custom-fields endpoint to check duplications of `order`s values.

## Approach
* added order property to custom field entity.
* added duplications check on POST /custom-fields for `order` property.
* added/updated tests.
