### PR TITLE
MODCFIELDS-18  Support custom field usage statistic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jeasy</groupId>
+      <artifactId>easy-random-core</artifactId>
+      <version>4.0.0.RC1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <version>5.1.1.RELEASE</version>
@@ -106,6 +112,20 @@
           <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,10 @@
     <folio-service-tools.version>1.2.0</folio-service-tools.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <sonar.exclusions>
+      src/main/java/**/ApplicationConfig.*
+    </sonar.exclusions>
   </properties>
 
   <dependencies>

--- a/ramls/custom-fields.raml
+++ b/ramls/custom-fields.raml
@@ -12,6 +12,7 @@ documentation:
 types:
   customFieldCollection: !include customFieldCollection.json
   customField: !include customField.json
+  customFieldStatisticCollection: !include customFieldStatisticCollection.json
   errors: !include raml-util/schemas/errors.schema
 
 traits:
@@ -23,6 +24,7 @@ traits:
 resourceTypes:
   collection: !include raml-util/rtypes/collection.raml
   collection-item: !include raml-util/rtypes/item-collection.raml
+  collection-readonly: !include raml-util/rtypes/get-only.raml
 
 
 /custom-fields:
@@ -48,3 +50,10 @@ resourceTypes:
       collection-item:
         schema: customField
         exampleItem: !include examples/customField.sample
+    /stats:
+      displayName: Custom field usage statistic
+      description: Returns usage statistic of custom field with the given id
+      type:
+        collection-readonly:
+          schema: customFieldStatisticCollection
+          exampleCollection: !include examples/customFieldStatisticCollection.sample

--- a/ramls/customField.json
+++ b/ramls/customField.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Collection of custom fields",
+  "description": "Custom field collection item",
   "additionalProperties": false,
   "properties": {
     "id": {

--- a/ramls/customFieldStatistic.json
+++ b/ramls/customFieldStatistic.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Custom field statistic collection item",
+  "additionalProperties": false,
+  "properties": {
+    "entityType": {
+      "type": "string",
+      "description": "The entity type, the custom field is assigned to",
+      "example": "package",
+      "readonly": true
+    },
+    "count": {
+      "type": "integer",
+      "description": "The number of usages by entity with the particular type",
+      "example": 3,
+      "readonly": true
+    }
+  },
+  "required": [
+    "entityType",
+    "count"
+  ]
+}

--- a/ramls/customFieldStatisticCollection.json
+++ b/ramls/customFieldStatisticCollection.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Collection of custom field usage",
+  "additionalProperties": false,
+  "properties": {
+    "stats": {
+      "type": "array",
+      "description": "An array of custom field usage statistic",
+      "items": {
+        "type": "object",
+        "$ref": "customFieldStatistic.json"
+      }
+    },
+    "totalRecords": {
+      "description": "Total number of records available, that match search conditions",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "stats",
+    "totalRecords"
+  ]
+}

--- a/ramls/examples/customFieldStatisticCollection.sample
+++ b/ramls/examples/customFieldStatisticCollection.sample
@@ -1,0 +1,13 @@
+{
+  "stats": [
+    {
+      "entityType": "package",
+      "count": 10
+    },
+    {
+      "entityType": "user",
+      "count": 3
+    }
+  ],
+  "totalRecords": 2
+}

--- a/src/main/java/org/folio/rest/impl/CustomFieldsImpl.java
+++ b/src/main/java/org/folio/rest/impl/CustomFieldsImpl.java
@@ -25,6 +25,7 @@ import org.folio.rest.annotations.Validate;
 import org.folio.rest.aspect.HandleValidationErrors;
 import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.CustomFieldCollection;
+import org.folio.rest.jaxrs.model.CustomFieldStatisticCollection;
 import org.folio.rest.jaxrs.resource.CustomFields;
 import org.folio.service.CustomFieldsService;
 import org.folio.spring.SpringContextUtil;
@@ -97,5 +98,14 @@ public class CustomFieldsImpl implements CustomFields {
       })
       .compose(o -> customFieldsService.update(id, entity, new OkapiParams(okapiHeaders)));
     respond(updated, v -> PutCustomFieldsByIdResponse.respond204(), asyncResultHandler, excHandler);
+  }
+
+  @Override
+  @Validate
+  public void getCustomFieldsStatsById(String id, String lang, Map<String, String> okapiHeaders,
+                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    Future<CustomFieldStatisticCollection> stats = customFieldsService.retrieveStatistic(id, tenantId(okapiHeaders));
+
+    respond(stats, GetCustomFieldsStatsByIdResponse::respond200WithApplicationJson, asyncResultHandler, excHandler);
   }
 }

--- a/src/main/java/org/folio/service/CustomFieldsService.java
+++ b/src/main/java/org/folio/service/CustomFieldsService.java
@@ -5,6 +5,7 @@ import io.vertx.core.Future;
 import org.folio.common.OkapiParams;
 import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.CustomFieldCollection;
+import org.folio.rest.jaxrs.model.CustomFieldStatisticCollection;
 
 public interface CustomFieldsService {
 
@@ -34,4 +35,6 @@ public interface CustomFieldsService {
    * Deletes custom field with given id.
    */
   Future<Void> delete(String id, String tenantId);
+
+  Future<CustomFieldStatisticCollection> retrieveStatistic(String id, String tenantId);
 }

--- a/src/main/java/org/folio/service/NoOpRecordService.java
+++ b/src/main/java/org/folio/service/NoOpRecordService.java
@@ -1,0 +1,28 @@
+package org.folio.service;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.Collections;
+
+import io.vertx.core.Future;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldStatisticCollection;
+
+public final class NoOpRecordService implements RecordService {
+
+  @Override
+  public Future<CustomFieldStatisticCollection> retrieveStatistic(CustomField field, String tenantId) {
+    return succeededFuture(
+      new CustomFieldStatisticCollection()
+        .withStats(Collections.emptyList())
+        .withTotalRecords(0)
+    );
+  }
+
+  @Override
+  public Future<Void> deleteAllValues(CustomField field, String tenantId) {
+    return succeededFuture();
+  }
+
+}

--- a/src/main/java/org/folio/service/RecordService.java
+++ b/src/main/java/org/folio/service/RecordService.java
@@ -1,0 +1,13 @@
+package org.folio.service;
+
+import io.vertx.core.Future;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldStatisticCollection;
+
+public interface RecordService {
+
+  Future<CustomFieldStatisticCollection> retrieveStatistic(CustomField field, String tenantId);
+
+  Future<Void> deleteAllValues(CustomField field, String tenantId);
+}

--- a/src/main/java/org/folio/service/spi/RecordServiceFactory.java
+++ b/src/main/java/org/folio/service/spi/RecordServiceFactory.java
@@ -1,0 +1,11 @@
+package org.folio.service.spi;
+
+import io.vertx.core.Vertx;
+
+import org.folio.service.RecordService;
+
+public interface RecordServiceFactory {
+
+  RecordService create(Vertx vertx);
+
+}

--- a/src/main/java/org/folio/spring/ApplicationConfig.java
+++ b/src/main/java/org/folio/spring/ApplicationConfig.java
@@ -9,8 +9,15 @@ import static org.folio.rest.exc.RestExceptionHandlers.generalHandler;
 import static org.folio.rest.exc.RestExceptionHandlers.logged;
 import static org.folio.rest.exceptions.CustomFieldTypeExceptionHandler.customFieldTypeValidationHandler;
 
+import java.util.Collection;
+
 import javax.ws.rs.core.Response;
 
+import io.vertx.core.ServiceHelper;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -21,6 +28,9 @@ import org.springframework.core.io.ClassPathResource;
 import org.folio.common.pf.PartialFunction;
 import org.folio.db.exc.translation.DBExceptionTranslator;
 import org.folio.db.exc.translation.DBExceptionTranslatorFactory;
+import org.folio.service.NoOpRecordService;
+import org.folio.service.RecordService;
+import org.folio.service.spi.RecordServiceFactory;
 
 @Configuration
 @ComponentScan(basePackages = {
@@ -29,12 +39,7 @@ import org.folio.db.exc.translation.DBExceptionTranslatorFactory;
   "org.folio.validate"})
 public class ApplicationConfig {
 
-  @Bean
-  public PropertySourcesPlaceholderConfigurer placeholderConfigurer() {
-    PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
-    configurer.setLocation(new ClassPathResource("custom-fields-application.properties"));
-    return configurer;
-  }
+  private final Logger logger = LoggerFactory.getLogger(ApplicationConfig.class);
 
   @Bean
   public PartialFunction<Throwable, Response> customFieldsExcHandler() {
@@ -51,5 +56,40 @@ public class ApplicationConfig {
   public DBExceptionTranslator excTranslator(@Value("${db.exception.translator.name:postgresql}") String translatorName) {
     DBExceptionTranslatorFactory factory = DBExceptionTranslatorFactory.instance();
     return factory.create(translatorName);
+  }
+
+  @Bean
+  public PropertySourcesPlaceholderConfigurer placeholderConfigurer() {
+    PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
+    configurer.setLocation(new ClassPathResource("custom-fields-application.properties"));
+    return configurer;
+  }
+
+  @Bean
+  public RecordService recordService(Vertx vertx) {
+    RecordService rc;
+
+    Collection<RecordServiceFactory> factories = ServiceHelper.loadFactories(RecordServiceFactory.class);
+
+    if (CollectionUtils.isEmpty(factories)) {
+      rc = new NoOpRecordService();
+
+      // log warning: No concrete implementation !!
+      logger.warn("No implementation of {} service provider interface found in the classpath.\n" +
+          "Check that the correct implementation class is set in META-INF/services/{} configuration file.\n" +
+          "The default No-op service will be used instead: some functions might not work properly!",
+          RecordServiceFactory.class.getName(), RecordServiceFactory.class.getName());
+    } else {
+      RecordServiceFactory factory = factories.iterator().next();
+      rc = factory.create(vertx);
+
+      if (factories.size() > 1) {
+        // log warning: too many implementations
+        logger.warn("Too many implementations of {} service provider interface found. The first one will be used: {}",
+          RecordServiceFactory.class.getName(), rc.getClass().getName());
+      }
+    }
+
+    return rc;
   }
 }

--- a/src/test/java/org/folio/service/NoOpRecordServiceTest.java
+++ b/src/test/java/org/folio/service/NoOpRecordServiceTest.java
@@ -1,0 +1,115 @@
+package org.folio.service;
+
+import static org.jeasy.random.FieldPredicates.named;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import io.vertx.core.Future;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.randomizers.misc.EnumRandomizer;
+import org.jeasy.random.randomizers.misc.UUIDRandomizer;
+import org.jeasy.random.randomizers.text.StringDelegatingRandomizer;
+import org.jeasy.random.randomizers.text.StringRandomizer;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldStatisticCollection;
+import org.folio.test.junit.TestStartLoggingRule;
+
+public class NoOpRecordServiceTest {
+
+  @Rule
+  public TestRule watcher = TestStartLoggingRule.instance();
+
+  private static EasyRandom cfRandom;
+  private static StringRandomizer tenantIdRandom;
+
+  private CustomField field;
+  private String tenantId;
+  private NoOpRecordService service;
+
+
+  @BeforeClass
+  public static void setUpClass() {
+    EasyRandomParameters params = new EasyRandomParameters()
+      .randomize(named("id"), StringDelegatingRandomizer.aNewStringDelegatingRandomizer(
+        UUIDRandomizer.aNewUUIDRandomizer()))
+      .randomize(named("name"), StringRandomizer.aNewStringRandomizer(20))
+      .randomize(named("refId"), StringRandomizer.aNewStringRandomizer(20))
+      .randomize(named("entityType"), StringDelegatingRandomizer.aNewStringDelegatingRandomizer(
+        EnumRandomizer.aNewEnumRandomizer(EntityType.class)))
+      .excludeField(named("metadata"));
+
+    cfRandom = new EasyRandom(params);
+
+    tenantIdRandom = StringRandomizer.aNewStringRandomizer(10);
+  }
+
+  @Before
+  public void setUp() {
+    field = nextRandomCustomField();
+    tenantId = nextRandomTenantId();
+
+    service = new NoOpRecordService();
+  }
+
+  @Test
+  public void shouldReturnEmptyStatistic() {
+    Future<CustomFieldStatisticCollection> stat = service.retrieveStatistic(field, tenantId);
+
+    assertNotNull(stat);
+    assertTrue(stat.succeeded());
+    assertEquals(stat.result(), new CustomFieldStatisticCollection()
+      .withStats(Collections.emptyList())
+      .withTotalRecords(0));
+  }
+
+  @Test
+  public void shouldReturnSuccessOnDeleteAllValues() {
+    Future<Void> res = service.deleteAllValues(field, tenantId);
+
+    assertNotNull(res);
+    assertTrue(res.succeeded());
+  }
+
+  private static CustomField nextRandomCustomField() {
+    return cfRandom.nextObject(CustomField.class);
+  }
+
+  private static String nextRandomTenantId() {
+    return tenantIdRandom.getRandomValue();
+  }
+
+  private enum EntityType {
+
+    PROVIDER("provider"),
+    PACKAGE("package"),
+    TITLE("title"),
+    RESOURCE("resource"),
+    USER("user"),
+    ORDER("order"),
+    ORDERLINE("orderline"),
+    ITEM("item"),
+    REQUEST("request");
+
+    private final String value;
+
+    EntityType(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+  }
+}


### PR DESCRIPTION
## Purpose
Per [MODCFIELDS-18](https://issues.folio.org/browse/MODCFIELDS-18), provide a way to retrieve CF usage statistics.

## Approach
- describe a new endpoint and data object in RAML
- introduce a service to get the collection of usages for a field: `RecordService`
- make the service be provided via SPI - RecordServiceFactory - so that other module could have their own implementation 
- create a default implementation of RecordService which does nothing. It should be used strictly inside mod-custom-fields
