### PR TITLE
Explain multiple interfaces in RAML documentation

### DIFF
--- a/ramls/custom-fields.raml
+++ b/ramls/custom-fields.raml
@@ -6,8 +6,14 @@ protocols: [ HTTP, HTTPS ]
 baseUri: https://github.com/folio-org/mod-custom-fields
 
 documentation:
-  - title: mod-custom-fields
-    content: This documents the API calls that can be made to manage custom fields
+  - title: mod-custom-fields, a library and common interface for custom fields to be used by several modules
+    content: |
+      FOLIO module library to store and maintain custom fields using Okapi's multiple interfaces feature.
+      All modules that use this library share the CRUD interface POST/PUT/GET/DELETE on /custom-fields and /custom-fields/$id endpoints.
+      The client must set the X-Okapi-Module-Id header, for details see
+      [Okapi multiples interfaces documentation](https://github.com/folio-org/okapi/blob/master/doc/guide.md#multiple-interfaces),
+      [mod-custom-fields introduction](https://github.com/folio-org/mod-custom-fields#introduction), and
+      [Custom Field backend demo](https://wiki.folio.org/pages/viewpage.action?spaceKey=FOLIJET&title=MODCFIELDS-39+-+Custom+Field+backend+demo).
 
 types:
   customFieldCollection: !include customFieldCollection.json


### PR DESCRIPTION
## Purpose
Clients get no hint about the multiple interfaces in the RAML documentation published at https://dev.folio.org/reference/api/ . This was discussed from May 9 till May 11 in Slack in #development.