### PR TITLE
MODCFIELDS-57 - Incorrect order of Custom Fields when drag-n-drop fields

### DIFF
--- a/src/main/java/org/folio/service/CustomFieldsServiceImpl.java
+++ b/src/main/java/org/folio/service/CustomFieldsServiceImpl.java
@@ -1,10 +1,35 @@
 package org.folio.service;
 
-import com.google.common.collect.Sets;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static java.lang.String.format;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.reverseOrder;
+import static org.folio.db.DbUtils.executeInTransactionWithVertxFuture;
+import static org.folio.service.CustomFieldUtils.extractDefaultOptionIds;
+import static org.folio.service.CustomFieldUtils.extractOptionIds;
+import static org.folio.service.CustomFieldUtils.isSelectableCustomFieldType;
+import static org.folio.service.CustomFieldUtils.isTextBoxCustomFieldType;
+
+import java.io.IOException;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.common.OkapiParams;
@@ -30,34 +55,12 @@ import org.z3950.zing.cql.CQLParser;
 import org.z3950.zing.cql.CQLSortNode;
 import org.z3950.zing.cql.ModifierSet;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.text.Normalizer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import com.google.common.collect.Sets;
 
-import static io.vertx.core.Future.failedFuture;
-import static io.vertx.core.Future.succeededFuture;
-import static java.lang.String.format;
-import static java.util.Comparator.comparing;
-import static java.util.Comparator.naturalOrder;
-import static java.util.Comparator.reverseOrder;
-import static org.folio.db.DbUtils.executeInTransactionWithVertxFuture;
-import static org.folio.service.CustomFieldUtils.extractDefaultOptionIds;
-import static org.folio.service.CustomFieldUtils.extractOptionIds;
-import static org.folio.service.CustomFieldUtils.isSelectableCustomFieldType;
-import static org.folio.service.CustomFieldUtils.isTextBoxCustomFieldType;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 @Component
 public class CustomFieldsServiceImpl implements CustomFieldsService {

--- a/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
@@ -1,27 +1,5 @@
 package org.folio.rest.impl;
 
-import io.restassured.http.Header;
-import io.vertx.core.json.Json;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.rest.jaxrs.model.CustomField;
-import org.folio.rest.jaxrs.model.CustomFieldCollection;
-import org.folio.rest.jaxrs.model.CustomFieldOptionStatistic;
-import org.folio.rest.jaxrs.model.CustomFieldStatistic;
-import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Metadata;
-import org.folio.rest.jaxrs.model.TextField;
-import org.folio.test.util.TestBase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
@@ -56,6 +34,29 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldCollection;
+import org.folio.rest.jaxrs.model.CustomFieldOptionStatistic;
+import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.jaxrs.model.TextField;
+import org.folio.test.util.TestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.restassured.http.Header;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class CustomFieldsImplTest extends TestBase {

--- a/src/test/resources/fields/put/putCustomFieldCollection.json
+++ b/src/test/resources/fields/put/putCustomFieldCollection.json
@@ -1,6 +1,14 @@
 {
   "customFields": [
     {
+      "name": "New Expiration Date",
+      "type" : "TEXTBOX_SHORT",
+      "visible": true,
+      "required": true,
+      "entityType": "package",
+      "helpText": "Set new expiration date"
+    },
+    {
       "name": "Department 2",
       "type" : "SINGLE_CHECKBOX",
       "refId": "not-null-ref-id",
@@ -11,14 +19,6 @@
       "checkboxField": {
         "default": true
       }
-    },
-    {
-      "name": "New Expiration Date",
-      "type" : "TEXTBOX_SHORT",
-      "visible": true,
-      "required": true,
-      "entityType": "package",
-      "helpText": "Set new expiration date"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
Fix for bug  https://issues.folio.org/browse/MODCFIELDS-57

## Approach
* updated functionality to update collection of custom fields on PUT
* updated/added tests

#### TODOS and Open Questions
- [ ] consider an option to delete endpoint PUT /custom-fields/{id} as it is unused on UI
 