### PR TITLE
MODCFIELDS-56 - Use camel-case names for auto-generated refIds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <raml-module-builder.version>30.0.2</raml-module-builder.version>
-    <folio-service-tools.version>1.5.0</folio-service-tools.version>
+    <folio-service-tools.version>1.5.1</folio-service-tools.version>
     <folio-di-support.version>1.1.0</folio-di-support.version>
     <lombok.version>1.18.4</lombok.version>
     <commons-validator.version>1.6</commons-validator.version>

--- a/src/main/java/org/folio/repository/CustomFieldsConstants.java
+++ b/src/main/java/org/folio/repository/CustomFieldsConstants.java
@@ -9,9 +9,9 @@ public final class CustomFieldsConstants {
   public static final String JSONB_COLUMN = "jsonb";
   public static final String ID_COLUMN = "id";
 
-  public static final String REF_ID_REGEX = "%s([1-9]\\d*)";
-  public static final String SELECT_REF_IDS = "SELECT unnest(regexp_matches(" + JSONB_COLUMN + " ->> 'refId', $1)) as "
-    + VALUES_COLUMN + " FROM %s";
+  public static final String REF_ID_REGEX = "%s(_([2-9]|[1-9]\\d+))?";
+  public static final String SELECT_REF_IDS = "SELECT "+ JSONB_COLUMN + " ->> 'refId' as "
+    + VALUES_COLUMN + " FROM %s WHERE " + JSONB_COLUMN + " ->> 'refId' SIMILAR TO $1" ;
   public static final String SELECT_MAX_ORDER = "SELECT MAX((jsonb ->> 'order')::int) as " + MAX_ORDER_COLUMN + " FROM %s";
   public static final String WHERE_ID_EQUALS_CLAUSE = "WHERE " + ID_COLUMN + "='%s'";
 

--- a/src/main/java/org/folio/repository/CustomFieldsConstants.java
+++ b/src/main/java/org/folio/repository/CustomFieldsConstants.java
@@ -9,7 +9,7 @@ public final class CustomFieldsConstants {
   public static final String JSONB_COLUMN = "jsonb";
   public static final String ID_COLUMN = "id";
 
-  public static final String REF_ID_REGEX = "%s_([1-9]\\d*)";
+  public static final String REF_ID_REGEX = "%s([1-9]\\d*)";
   public static final String SELECT_REF_IDS = "SELECT unnest(regexp_matches(" + JSONB_COLUMN + " ->> 'refId', $1)) as "
     + VALUES_COLUMN + " FROM %s";
   public static final String SELECT_MAX_ORDER = "SELECT MAX((jsonb ->> 'order')::int) as " + MAX_ORDER_COLUMN + " FROM %s";

--- a/src/main/java/org/folio/repository/CustomFieldsRepositoryImpl.java
+++ b/src/main/java/org/folio/repository/CustomFieldsRepositoryImpl.java
@@ -163,8 +163,13 @@ public class CustomFieldsRepositoryImpl implements CustomFieldsRepository {
   }
 
   private Integer mapMaxRefId(RowSet<Row> rowSet) {
+    if (rowSet.rowCount() == 1 && !RowSetUtils.mapFirstItem(rowSet, row -> row.getString(VALUES_COLUMN)).contains("_")) {
+      return 1;
+    }
     return RowSetUtils.streamOf(rowSet)
       .map(row -> row.getString(VALUES_COLUMN))
+      .map(s -> StringUtils.substringAfter(s, "_"))
+      .filter(StringUtils::isNotBlank)
       .mapToInt(Integer::parseInt)
       .max().orElse(0);
   }

--- a/src/main/java/org/folio/service/CustomFieldsServiceImpl.java
+++ b/src/main/java/org/folio/service/CustomFieldsServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang.WordUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.common.OkapiParams;
 import org.folio.model.RecordUpdate;
@@ -381,10 +382,13 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
   }
 
   private String unAccentName(String customFieldName) {
-    return Normalizer.normalize(customFieldName, Normalizer.Form.NFD)
+    final String capitalizedString = WordUtils.capitalizeFully(customFieldName);
+    final String splitString = Normalizer.normalize(capitalizedString, Normalizer.Form.NFD)
       .replaceAll("\\p{InCombiningDiacriticalMarks}+", "")
       .replaceAll("[^a-zA-Z\\s]", "")
-      .replaceAll("\\s+", "-").toLowerCase();
+      .replaceAll("\\s+", "");
+
+    return StringUtils.uncapitalize(splitString);
   }
 
   private String getCustomFieldRefId(String id, Integer maxRefId) {

--- a/src/main/resources/templates/db_scripts/migrate-to-new-ref-id-format.sql
+++ b/src/main/resources/templates/db_scripts/migrate-to-new-ref-id-format.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.camel_case_format(instr varchar) RETURNS varchar AS $$
+DECLARE
+BEGIN
+  RETURN lower(left(instr, 1)) || right(regexp_replace(initcap(instr), '-|_1', '', 'g'), -1);
+END;
+$$ LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.update_users_ref_ids() RETURNS TRIGGER
+AS $update_users_ref_ids$
+  DECLARE
+  	newRefId text;
+    oldRefId text;
+  BEGIN
+    newRefId = NEW.jsonb->>'refId';
+    oldRefId = OLD.jsonb->>'refId';
+  UPDATE
+     ${myuniversity}_${mymodule}.users
+  SET
+  jsonb = jsonb_set(jsonb, '{customFields}', ((jsonb->'customFields' || jsonb_build_object(newRefId, jsonb->'customFields'->oldRefId))) - oldRefId) WHERE jsonb->'customFields'->oldRefId IS NOT NULL;
+    RETURN NEW;
+  END;
+$update_users_ref_ids$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_users_ref_ids_trigger ON ${myuniversity}_${mymodule}.custom_fields;
+CREATE TRIGGER update_users_ref_ids_trigger
+BEFORE UPDATE ON ${myuniversity}_${mymodule}.custom_fields FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.update_users_ref_ids();
+
+DROP TRIGGER IF EXISTS update_ref_id_trigger ON ${myuniversity}_${mymodule}.custom_fields;
+
+UPDATE
+${myuniversity}_${mymodule}.custom_fields
+SET
+jsonb = jsonb_set(jsonb, '{refId}', to_jsonb(${myuniversity}_${mymodule}.camel_case_format(jsonb->>'refId')));
+
+DROP TRIGGER IF EXISTS update_users_ref_ids_trigger ON ${myuniversity}_${mymodule}.custom_fields;
+DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.camel_case_format;
+DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.update_users_ref_ids;
+
+CREATE TRIGGER update_ref_id_trigger BEFORE UPDATE ON ${myuniversity}_${mymodule}.custom_fields FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.update_ref_id();

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -9,6 +9,11 @@
       "run": "after",
       "snippetPath": "update-textbox-default-format.sql",
       "fromModuleVersion": "1.4.1"
+    },
+    {
+      "run": "after",
+      "snippetPath": "migrate-to-new-ref-id-format.sql",
+      "fromModuleVersion": "1.4.1"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
@@ -71,7 +71,7 @@ public class CustomFieldsImplTest extends TestBase {
   public void postCustomFields() throws IOException, URISyntaxException {
     CustomField customField = createCustomField(readFile("fields/post/singleSelect/postValidSingleSelect.json"));
 
-    assertEquals("favoritefood1", customField.getRefId());
+    assertEquals("favoriteFood", customField.getRefId());
     assertThat(customField.getSelectField().getOptions().getValues(),
       hasItem(hasProperty("id", equalTo("opt_2")))
     );
@@ -100,16 +100,16 @@ public class CustomFieldsImplTest extends TestBase {
   public void shouldCreateTwoRefIdOnPostCustomFieldWithSameName() throws IOException, URISyntaxException {
     CustomField cfWithAccentName1 = createCustomField(readFile("fields/post/postCustomFieldWithAccentName.json"));
     CustomField cfWithAccentName2 = createCustomField(readFile("fields/post/postCustomFieldWithAccentNameSecond.json"));
-    assertEquals("thisIsATrickyString1", cfWithAccentName1.getRefId());
-    assertEquals("thisIsATrickyString2", cfWithAccentName2.getRefId());
+    assertEquals("thisIsATrickyString", cfWithAccentName1.getRefId());
+    assertEquals("thisIsATrickyString_2", cfWithAccentName2.getRefId());
   }
 
   @Test
   public void shouldCreateTwoRefIdOnPostCustomFieldWithSameName2() throws IOException, URISyntaxException {
     CustomField cfWithAccentName = createCustomField(readFile("fields/post/postCustomFieldWithAccentName.json"));
     CustomField cfWithHalfName = createCustomField(readFile("fields/post/postCustomFieldHalfName2.json"));
-    assertEquals("thisIsATrickyString1", cfWithAccentName.getRefId());
-    assertEquals("thisIsA1", cfWithHalfName.getRefId());
+    assertEquals("thisIsATrickyString", cfWithAccentName.getRefId());
+    assertEquals("thisIsA", cfWithHalfName.getRefId());
   }
 
   @Test
@@ -121,7 +121,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomFieldCollection fields = getWithOk(CUSTOM_FIELDS_PATH + "?limit=500&offset0").as(CustomFieldCollection.class);
     final List<CustomField> customFields = fields.getCustomFields();
-    for (int i = 0; i < customFields.size(); i++) {
+    for (int i = 1; i < customFields.size(); i++) {
       assertTrue(customFields.get(i).getRefId().contains(String.valueOf(i + 1)));
     }
   }
@@ -294,7 +294,7 @@ public class CustomFieldsImplTest extends TestBase {
     CustomField actual = getWithOk(itemResourcePath(customField.getId())).as(CustomField.class);
 
     assertEquals("Department", actual.getName());
-    assertEquals("department1", actual.getRefId());
+    assertEquals("department", actual.getRefId());
     assertEquals("Provide a department", actual.getHelpText());
     assertEquals(true, actual.getRequired());
     assertEquals(true, actual.getVisible());
@@ -330,7 +330,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField actual = getAllCustomFields(vertx).get(0);
     assertEquals("favoriteFood 2", actual.getName());
-    assertEquals("favoritefood1", actual.getRefId());
+    assertEquals("favoritefood", actual.getRefId());
     assertEquals("Choose your favorite food", actual.getHelpText());
     assertEquals(true, actual.getRequired());
     assertEquals(true, actual.getVisible());
@@ -353,7 +353,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField field = getAllCustomFields(vertx).get(0);
     assertEquals("Expiration Date", field.getName());
-    assertEquals("expirationDate1", field.getRefId());
+    assertEquals("expirationDate", field.getRefId());
     assertEquals("Set expiration date", field.getHelpText());
     assertEquals(true, field.getRequired());
     assertEquals(true, field.getVisible());
@@ -444,7 +444,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField firstFieldUpdated = customFieldsAfterUpdate.get(0);
     assertEquals("New Expiration Date", firstFieldUpdated.getName());
-    assertEquals("newExpirationDate1", firstFieldUpdated.getRefId());
+    assertEquals("newExpirationDate", firstFieldUpdated.getRefId());
     assertEquals("Set new expiration date", firstFieldUpdated.getHelpText());
     assertEquals(true, firstFieldUpdated.getRequired());
     assertEquals(true, firstFieldUpdated.getVisible());
@@ -458,7 +458,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField secondFieldUpdated = customFieldsAfterUpdate.get(1);
     assertEquals("Department 2", secondFieldUpdated.getName());
-    assertEquals("department1", secondFieldUpdated.getRefId());
+    assertEquals("department", secondFieldUpdated.getRefId());
     assertEquals("Provide a second department", secondFieldUpdated.getHelpText());
     assertEquals(false, secondFieldUpdated.getRequired());
     assertEquals(false, secondFieldUpdated.getVisible());
@@ -501,7 +501,7 @@ public class CustomFieldsImplTest extends TestBase {
     assertEquals(2, customFieldsAfterUpdate.size());
 
     assertEquals(1, (int) firstFieldUpdated.getOrder());
-    assertEquals("expirationDate2",  firstFieldUpdated.getRefId());
+    assertEquals("expirationDate_2",  firstFieldUpdated.getRefId());
 
     assertEquals(2, (int) secondFieldUpdated.getOrder());
     assertEquals(cfNameUpdated, secondFieldUpdated.getName());

--- a/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsImplTest.java
@@ -71,7 +71,7 @@ public class CustomFieldsImplTest extends TestBase {
   public void postCustomFields() throws IOException, URISyntaxException {
     CustomField customField = createCustomField(readFile("fields/post/singleSelect/postValidSingleSelect.json"));
 
-    assertEquals("favoritefood_1", customField.getRefId());
+    assertEquals("favoritefood1", customField.getRefId());
     assertThat(customField.getSelectField().getOptions().getValues(),
       hasItem(hasProperty("id", equalTo("opt_2")))
     );
@@ -100,16 +100,16 @@ public class CustomFieldsImplTest extends TestBase {
   public void shouldCreateTwoRefIdOnPostCustomFieldWithSameName() throws IOException, URISyntaxException {
     CustomField cfWithAccentName1 = createCustomField(readFile("fields/post/postCustomFieldWithAccentName.json"));
     CustomField cfWithAccentName2 = createCustomField(readFile("fields/post/postCustomFieldWithAccentNameSecond.json"));
-    assertEquals("this-is-a-tricky-string_1", cfWithAccentName1.getRefId());
-    assertEquals("this-is-a-tricky-string_2", cfWithAccentName2.getRefId());
+    assertEquals("thisIsATrickyString1", cfWithAccentName1.getRefId());
+    assertEquals("thisIsATrickyString2", cfWithAccentName2.getRefId());
   }
 
   @Test
   public void shouldCreateTwoRefIdOnPostCustomFieldWithSameName2() throws IOException, URISyntaxException {
     CustomField cfWithAccentName = createCustomField(readFile("fields/post/postCustomFieldWithAccentName.json"));
     CustomField cfWithHalfName = createCustomField(readFile("fields/post/postCustomFieldHalfName2.json"));
-    assertEquals("this-is-a-tricky-string_1", cfWithAccentName.getRefId());
-    assertEquals("this-is-a_1", cfWithHalfName.getRefId());
+    assertEquals("thisIsATrickyString1", cfWithAccentName.getRefId());
+    assertEquals("thisIsA1", cfWithHalfName.getRefId());
   }
 
   @Test
@@ -294,7 +294,7 @@ public class CustomFieldsImplTest extends TestBase {
     CustomField actual = getWithOk(itemResourcePath(customField.getId())).as(CustomField.class);
 
     assertEquals("Department", actual.getName());
-    assertEquals("department_1", actual.getRefId());
+    assertEquals("department1", actual.getRefId());
     assertEquals("Provide a department", actual.getHelpText());
     assertEquals(true, actual.getRequired());
     assertEquals(true, actual.getVisible());
@@ -330,7 +330,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField actual = getAllCustomFields(vertx).get(0);
     assertEquals("favoriteFood 2", actual.getName());
-    assertEquals("favoritefood_1", actual.getRefId());
+    assertEquals("favoritefood1", actual.getRefId());
     assertEquals("Choose your favorite food", actual.getHelpText());
     assertEquals(true, actual.getRequired());
     assertEquals(true, actual.getVisible());
@@ -353,7 +353,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField field = getAllCustomFields(vertx).get(0);
     assertEquals("Expiration Date", field.getName());
-    assertEquals("expiration-date_1", field.getRefId());
+    assertEquals("expirationDate1", field.getRefId());
     assertEquals("Set expiration date", field.getHelpText());
     assertEquals(true, field.getRequired());
     assertEquals(true, field.getVisible());
@@ -444,7 +444,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField firstFieldUpdated = customFieldsAfterUpdate.get(0);
     assertEquals("New Expiration Date", firstFieldUpdated.getName());
-    assertEquals("new-expiration-date_1", firstFieldUpdated.getRefId());
+    assertEquals("newExpirationDate1", firstFieldUpdated.getRefId());
     assertEquals("Set new expiration date", firstFieldUpdated.getHelpText());
     assertEquals(true, firstFieldUpdated.getRequired());
     assertEquals(true, firstFieldUpdated.getVisible());
@@ -458,7 +458,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField secondFieldUpdated = customFieldsAfterUpdate.get(1);
     assertEquals("Department 2", secondFieldUpdated.getName());
-    assertEquals("department_1", secondFieldUpdated.getRefId());
+    assertEquals("department1", secondFieldUpdated.getRefId());
     assertEquals("Provide a second department", secondFieldUpdated.getHelpText());
     assertEquals(false, secondFieldUpdated.getRequired());
     assertEquals(false, secondFieldUpdated.getVisible());
@@ -501,7 +501,7 @@ public class CustomFieldsImplTest extends TestBase {
     assertEquals(2, customFieldsAfterUpdate.size());
 
     assertEquals(1, (int) firstFieldUpdated.getOrder());
-    assertEquals("expiration-date_2",  firstFieldUpdated.getRefId());
+    assertEquals("expirationDate2",  firstFieldUpdated.getRefId());
 
     assertEquals(2, (int) secondFieldUpdated.getOrder());
     assertEquals(cfNameUpdated, secondFieldUpdated.getName());
@@ -625,7 +625,7 @@ public class CustomFieldsImplTest extends TestBase {
 
     CustomField customFieldThree = createCustomField(readFile("fields/post/postCustomFieldOrder3.json"));
 
-    assertTrue(customFieldThree.getRefId().endsWith("_3"));
+    assertTrue(customFieldThree.getRefId().endsWith("3"));
   }
 
   @Test

--- a/src/test/java/org/folio/validate/ValidationServiceImplTest.java
+++ b/src/test/java/org/folio/validate/ValidationServiceImplTest.java
@@ -1,7 +1,6 @@
 package org.folio.validate;
 
 import static org.apache.http.HttpStatus.SC_CREATED;
-
 import static org.folio.CustomFieldsTestUtil.CUSTOM_FIELDS_PATH;
 import static org.folio.CustomFieldsTestUtil.USER1_HEADER;
 import static org.folio.CustomFieldsTestUtil.mockUserRequests;
@@ -11,22 +10,22 @@ import static org.folio.test.util.TestUtil.readFile;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import io.vertx.core.Context;
-import io.vertx.core.json.Json;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.CustomFieldsTestUtil;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.spring.SpringContextUtil;
+import org.folio.test.util.TestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import org.folio.CustomFieldsTestUtil;
-import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.model.Parameter;
-import org.folio.spring.SpringContextUtil;
-import org.folio.test.util.TestBase;
+import io.vertx.core.Context;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class ValidationServiceImplTest extends TestBase {
@@ -52,7 +51,7 @@ public class ValidationServiceImplTest extends TestBase {
   public void shouldReturnSuccessfulFutureIfValidationSucceeds(TestContext context) throws IOException, URISyntaxException {
     createRadioButtonField();
     Async async = context.async();
-    CustomFieldValue customFieldValue = Json.decodeValue("{\"favoritefood_1\":\"opt_1\"}", CustomFieldValue.class);
+    CustomFieldValue customFieldValue = Json.decodeValue("{\"favoritefood1\":\"opt_1\"}", CustomFieldValue.class);
     validationService
       .validateCustomFields(customFieldValue.getAdditionalProperties(), STUB_TENANT)
       .map(o -> {
@@ -69,7 +68,7 @@ public class ValidationServiceImplTest extends TestBase {
   public void shouldReturnAnErrorIfValidationFails(TestContext context) throws IOException, URISyntaxException {
     createRadioButtonField();
     Async async = context.async();
-    CustomFieldValue customFieldValue = Json.decodeValue("{\"favoritefood_1\":\"opt_5\"}", CustomFieldValue.class);
+    CustomFieldValue customFieldValue = Json.decodeValue("{\"favoritefood1\":\"opt_5\"}", CustomFieldValue.class);
     validationService.validateCustomFields(customFieldValue.getAdditionalProperties(), STUB_TENANT)
       .onComplete(validation -> {
         if (validation.failed()) {
@@ -79,7 +78,7 @@ public class ValidationServiceImplTest extends TestBase {
           } else {
             Errors errors = ((CustomFieldValidationException) cause).getErrors();
             Parameter errorParam = errors.getErrors().get(0).getParameters().get(0);
-            context.assertEquals("favoritefood_1", errorParam.getKey());
+            context.assertEquals("favoritefood1", errorParam.getKey());
             context.assertEquals("\"opt_5\"", errorParam.getValue());
           }
         } else {

--- a/src/test/java/org/folio/validate/ValidationServiceImplTest.java
+++ b/src/test/java/org/folio/validate/ValidationServiceImplTest.java
@@ -51,7 +51,7 @@ public class ValidationServiceImplTest extends TestBase {
   public void shouldReturnSuccessfulFutureIfValidationSucceeds(TestContext context) throws IOException, URISyntaxException {
     createRadioButtonField();
     Async async = context.async();
-    CustomFieldValue customFieldValue = Json.decodeValue("{\"favoritefood1\":\"opt_1\"}", CustomFieldValue.class);
+    CustomFieldValue customFieldValue = Json.decodeValue("{\"favoritefood\":\"opt_1\"}", CustomFieldValue.class);
     validationService
       .validateCustomFields(customFieldValue.getAdditionalProperties(), STUB_TENANT)
       .map(o -> {
@@ -68,7 +68,7 @@ public class ValidationServiceImplTest extends TestBase {
   public void shouldReturnAnErrorIfValidationFails(TestContext context) throws IOException, URISyntaxException {
     createRadioButtonField();
     Async async = context.async();
-    CustomFieldValue customFieldValue = Json.decodeValue("{\"favoritefood1\":\"opt_5\"}", CustomFieldValue.class);
+    CustomFieldValue customFieldValue = Json.decodeValue("{\"favoritefood\":\"opt_5\"}", CustomFieldValue.class);
     validationService.validateCustomFields(customFieldValue.getAdditionalProperties(), STUB_TENANT)
       .onComplete(validation -> {
         if (validation.failed()) {
@@ -78,7 +78,7 @@ public class ValidationServiceImplTest extends TestBase {
           } else {
             Errors errors = ((CustomFieldValidationException) cause).getErrors();
             Parameter errorParam = errors.getErrors().get(0).getParameters().get(0);
-            context.assertEquals("favoritefood1", errorParam.getKey());
+            context.assertEquals("favoritefood", errorParam.getKey());
             context.assertEquals("\"opt_5\"", errorParam.getValue());
           }
         } else {

--- a/src/test/resources/fields/post/postCustomFieldWithAccentName.json
+++ b/src/test/resources/fields/post/postCustomFieldWithAccentName.json
@@ -1,5 +1,5 @@
 {
-  "name": "Tĥïŝ ĩš â ťŕĭçķŷ Šťŕĭńġ",
+  "name": "Tĥïŝ ĩš â ťŕĭçķŷ ŠťŕĭńġØŁ",
   "visible": true,
   "required": true,
   "type": "SINGLE_CHECKBOX",

--- a/src/test/resources/fields/post/singleSelect/postValidSingleSelect.json
+++ b/src/test/resources/fields/post/singleSelect/postValidSingleSelect.json
@@ -1,5 +1,5 @@
 {
-  "name": "favoriteFood",
+  "name": "Favorite Food",
   "visible": true,
   "required": true,
   "type": "SINGLE_SELECT_DROPDOWN",


### PR DESCRIPTION
## Purpose
Use camel-case names for auto-generated refIds, only use counter value if needed

## Approach
+ change refId generate algorithm
+ update tests
+ create migration scripts

## TODOs
- [x] Merge https://github.com/folio-org/mod-users/pull/178 after this